### PR TITLE
ncmb.User.requestPasswordReset(email) メソッドを追加

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -17,6 +17,11 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - name: install latest npm
+      run: |
+        npm install -g npm &&
+        npm --version &&
+        npm list -g --depth 0
     - run: npm install
     - run: npm run build --if-present
     - run: npm test

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -1,6 +1,6 @@
 name: js
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/lib/user.js
+++ b/lib/user.js
@@ -258,6 +258,37 @@ var User = module.exports = function(ncmb){
   };
 
   /**
+  * パスワードをリセットするために指定したmailAddressメールアドレスにメールを送信します。
+  *
+  * @method NCMB.UserConstructor#requestPasswordReset
+  * @param {string} mailAddress 登録するメールアドレス
+  * @param {function} [callback] コールバック関数
+  * @return {Promise<any>} APIレスポンス
+  */
+  User.requestPasswordReset = function(mailAddress,callback){
+    if (! mailAddress) {
+       return ( callback || Promise.reject.bind(Promise))(new Errors.NoMailAddressError("MailAddress must be set."));
+    }
+    return ncmb.request({
+      path: "/" + ncmb.version + "/requestPasswordReset",
+      method: "POST",
+      data: {'mailAddress': mailAddress }
+    }).then(function(data){
+      var obj = null;
+      try{
+        obj = JSON.parse(data);
+      }catch(err){
+        throw err;
+      }
+      if(callback) return callback(null, obj);
+      return obj;
+    }).catch(function(err){
+      if(callback) return callback(err, null);
+      throw err;
+    });
+  };
+
+  /**
   * メールアドレス認証の登録メールを送信します。
   * メール内でパスワード入力を行い、登録が完了した時点で認証が可能となります。
   *

--- a/test/users_test.js
+++ b/test/users_test.js
@@ -3760,11 +3760,13 @@ describe("NCMB Users", function(){
       beforeEach(function(){
         user = new ncmb.User({ mailAddress: "test@example.com" });
       });
+
       it("callback でレスポンスを取得できる", function(done){
         user.requestPasswordReset(function(err, data){
           done(err ? err : null);
         });
       });
+
       it("promise でレスポンスを取得できる", function(done){
         user.requestPasswordReset()
         .then(function(data){
@@ -3774,6 +3776,23 @@ describe("NCMB Users", function(){
           done(err);
         });
       });
+
+      it("NEW: callback でレスポンスを取得できる", function(done){
+        ncmb.User.requestPasswordReset("test@example.com", function(err, data){
+          done(err ? err : null);
+        });
+      });
+
+      it("NEW: promise でレスポンスを取得できる", function(done){
+        ncmb.User.requestPasswordReset("test@example.com")
+        .then(function(data){
+          done();
+        })
+        .catch(function(err){
+          done(err);
+        });
+      });
+
     });
 
     context("失敗した理由が", function(){

--- a/test/users_test.js
+++ b/test/users_test.js
@@ -3777,13 +3777,13 @@ describe("NCMB Users", function(){
         });
       });
 
-      it("NEW: callback でレスポンスを取得できる", function(done){
+      it("ncmb.User.requestPasswordReset: callback でレスポンスを取得できる", function(done){
         ncmb.User.requestPasswordReset("test@example.com", function(err, data){
           done(err ? err : null);
         });
       });
 
-      it("NEW: promise でレスポンスを取得できる", function(done){
+      it("ncmb.User.requestPasswordReset: promise でレスポンスを取得できる", function(done){
         ncmb.User.requestPasswordReset("test@example.com")
         .then(function(data){
           done();


### PR DESCRIPTION
## 概要(Summary)

- 従来は以下のようにメソッド利用することはできますが、より便利性を向上し、以下のメソッドを追加します
  - 従来方法
```js
ncmb.User.requestPasswordReset()
  .then(function(){
    /* 再設定メール送信成功時の処理（例） */
    console.log("再設定メール送信成功");
  })
  .catch(function(error){
    /* 再設定メール送信失敗時の処理（例） */
    console.log("再設定メール送信失敗:" + JSON.stringify(error));
  });
```
  - 今回追加
```js
ncmb.User.requestPasswordReset(email)
  .then(function(){
    /* 再設定メール送信成功時の処理（例） */
    console.log("再設定メール送信成功");
  })
  .catch(function(error){
    /* 再設定メール送信失敗時の処理（例） */
    console.log("再設定メール送信失敗:" + JSON.stringify(error));
  });

```

## 動作確認手順(Step for Confirmation)

Run the unit test.
