### PR TITLE
Github CI自動チェックフローを更新：NodeJS18対応など

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -1,6 +1,6 @@
 name: js
 
-on: [pull_request]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 18.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -12,22 +12,13 @@ jobs:
         node-version: [14.x, 16.x, 18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - name: 'change version'
-      uses: reedyuk/npm-version@1.1.1
-      with:
-        version: '8.11.0'
-        package: 'subproject-directory/'
-        git-tag-version: 'true'
-    - run: npm install
-    - run: npm run build --if-present
+    - run: npm ci
     - run: npm test
-      env:
-        CI: true
     - name: Archive production artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -17,6 +17,12 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - name: 'change version'
+      uses: reedyuk/npm-version@1.1.1
+      with:
+        version: '8.11.0'
+        package: 'subproject-directory/'
+        git-tag-version: 'true'
     - run: npm install
     - run: npm run build --if-present
     - run: npm test

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -17,8 +17,11 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - name: npm 8
-      run: npm i -g npm@8 --registry=https://registry.npmjs.org
+    - name: install latest npm
+      run: |
+        npm install -g npm &&
+        npm --version &&
+        npm list -g --depth 0
     - run: npm install
     - run: npm run build --if-present
     - run: npm test

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -1,6 +1,6 @@
 name: js
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v3
@@ -17,6 +17,8 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+    - name: npm 8
+      run: npm i -g npm@8 --registry=https://registry.npmjs.org
     - run: npm install
     - run: npm run build --if-present
     - run: npm test

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -17,8 +17,11 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm ci
+    - run: npm install
+    - run: npm run build --if-present
     - run: npm test
+      env:
+        CI: true
     - name: Archive production artifacts
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
## 概要(Summary)

- Github CI自動チェックフローを更新：
   - NodeJS 18のテストを追加
   - NodeJS 10, 12を除外
   - ジョブが利用するnpmバージョンを更新

## 動作確認手順(Step for Confirmation)

Run the unit test.
