### PR TITLE
Update actions/upload-artifact to v3

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -28,7 +28,7 @@ jobs:
       env:
         CI: true
     - name: Archive production artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ncmb_min_js
         path: ncmb.min.js

--- a/.github/workflows/reference.yml
+++ b/.github/workflows/reference.yml
@@ -50,7 +50,7 @@ jobs:
       run: zip -r docs.zip docs/
 
     - name: Archive artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: docs
         path: docs.zip


### PR DESCRIPTION
## 概要(Summary)

- ワークフローで非推奨がでています
```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

- actions/upload-artifactを`v2`から`v3`にアップデートすることで解消されます
  - Node 12 からNode 16へ変更されているバージョンアップです

## 動作確認手順(Step for Confirmation)

- ワークフローの結果に警告が表示されない
  - https://github.com/NIFCLOUD-mbaas/ncmb_js/actions/runs/4180485465
- ncmb.min.jsのアップロードに成功している